### PR TITLE
Add info on installing serverless cli to template

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -6,6 +6,10 @@ This project uses the `lambda-slack-router` node module found here: <https://git
 
 ## Configuration
 
+Install the serverless cli:
+
+    $ npm install -g serverless
+
 Install the necessary node modules by running `npm install` in both the root directory and `nodejs` directory:
 
     $ npm install


### PR DESCRIPTION
This was a step that was missing for someone who is brand new to serverless and might not have the cli installed already.